### PR TITLE
update wakuv2 fleet DNS discovery enrtree

### DIFF
--- a/waku/common/commons.go
+++ b/waku/common/commons.go
@@ -12,7 +12,7 @@ const PortRange = 1000
 const GraceWait = 10 // percentage
 const InterPubSubDelay = 25 // seconds
 
-const DnsDiscoveryUrl = "enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@prod.waku.nodes.status.im"
+const DnsDiscoveryUrl = "enrtree://ANEDLO25QVUGJOUTQFRYKWX6P4Z4GKVESBMHML7DZ6YK4LGS5FC5O@prod.wakuv2.nodes.status.im"
 const NameServer = "1.1.1.1"
 const LocalHost = "0.0.0.0"
 

--- a/waku/filter/filter.go
+++ b/waku/filter/filter.go
@@ -31,7 +31,7 @@ var log = logging.Logger("filter")
 var pubSubTopic = protocol.DefaultPubsubTopic()
 var conf = common.Config{}
 var nodeType = "filter"
-//const dnsDiscoveryUrl = "enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@prod.waku.nodes.status.im"
+//const dnsDiscoveryUrl = "enrtree://ANEDLO25QVUGJOUTQFRYKWX6P4Z4GKVESBMHML7DZ6YK4LGS5FC5O@prod.wakuv2.nodes.status.im"
 //const nameServer = "1.1.1.1" // your local dns provider might be blocking entr
 
 

--- a/waku/subscribe/subscribe.go
+++ b/waku/subscribe/subscribe.go
@@ -31,7 +31,7 @@ var log = logging.Logger("subscribe")
 var pubSubTopic = protocol.DefaultPubsubTopic()
 var conf = common.Config{}
 var nodeType = "subscribe"
-//const dnsDiscoveryUrl = "enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@prod.waku.nodes.status.im"
+//const dnsDiscoveryUrl = "enrtree://ANEDLO25QVUGJOUTQFRYKWX6P4Z4GKVESBMHML7DZ6YK4LGS5FC5O@prod.wakuv2.nodes.status.im"
 //const nameServer = "1.1.1.1" // your local dns provider might be blocking entr
 
 


### PR DESCRIPTION
Enrtrees were regenerated. Need to update the old one.
DNS discoverty should continue to work.